### PR TITLE
Bugfix/build not publish

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -92,8 +92,8 @@ func Build(cfg *project.Project, jobs ...*Job) error {
 				)
 			}
 
-			log.Println("publishing", job.PublishImageName)
-			hash, err := container.Publish(ctx, job.PublishImageName)
+			log.Println("publishing", job.PublishImageName, "to", job.ImageName)
+			hash, err := container.Publish(ctx, job.ImageName)
 			if err != nil {
 				return job.Name, err
 			}

--- a/builder/job.go
+++ b/builder/job.go
@@ -89,5 +89,7 @@ func JobFromModule(cfg *project.Project, name string, mod *project.Module) (*Job
 		BinaryArgs:  mod.BinaryArgs,
 		AssetDirs:   mod.AssetDirs,
 		Env:         mod.Env,
+
+		Publish: mod.Publish,
 	}, nil
 }

--- a/project/project.go
+++ b/project/project.go
@@ -39,6 +39,8 @@ type (
 		BinaryArgs  []string          `toml:"binary_args"`
 		AssetDirs   []string          `toml:"asset_dirs"`
 		Env         map[string]string `toml:"env"`
+
+		Publish bool `toml:publish`
 	}
 )
 


### PR DESCRIPTION
- Add Publish attribute to Job 
- Using job.ImageName instead of job.PublishImageName(NULL) for docker registry address