### PR TITLE
Feature/build publish improvement

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -56,6 +56,11 @@ func runPublish(cmd *cobra.Command, args []string) {
 	}
 	defer sess.Close()
 
+	// Tag the image with the release name
+	for _, job := range jobs {
+		job.ImageName = job.ImageName + ":" + rel.Name
+	}
+
 	builds, err := builder.Build(sess, jobs...)
 	if err != nil {
 		plog.Fatalln(err)

--- a/releases/dateref/dateref.go
+++ b/releases/dateref/dateref.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-var refRegexp = regexp.MustCompile("^v([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})$")
+var refRegexp = regexp.MustCompile("^v([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})(-[0-9]+)?$")
 
 // Jan 2 15:04:05 2006 MST
 const refFormat = "v200601021504"

--- a/releases/dateref/dateref.go
+++ b/releases/dateref/dateref.go
@@ -5,10 +5,10 @@ import (
 	"time"
 )
 
-var refRegexp = regexp.MustCompile("^v([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})(-[0-9]+)?$")
+var refRegexp = regexp.MustCompile("^v([0-9]{4})([0-9]{2})([0-9]{2})(-[0-9]+)?$")
 
 // Jan 2 15:04:05 2006 MST
-const refFormat = "v200601021504"
+const refFormat = "v20060102-01"
 
 func Now() string {
 	return time.Now().Format(refFormat)


### PR DESCRIPTION
- Allow the platform to tag the image with the release name instead of publishing `latest` tag
- Using timestamp format v{year}{month}{date}{hour}{minute} would be hard for developer to tag the release and hard to remember I suggest that we using v{year}{month}{date}[-version] instead